### PR TITLE
switch to uber-go/zap

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/errors"
-	"github.com/ngaut/log"
+	"go.uber.org/zap"
 )
 
 func NewConfig() *Config {
@@ -26,7 +27,6 @@ func NewConfig() *Config {
 	fs.StringVar(&cfg.TidbSnapshot, "tidb-snapshot", "", "Set the backup to a point in time.")
 
 	fs.StringVar(&cfg.LogLevel, "L", "info", "Loader log level: debug, info, warn, error, fatal")
-	//log file
 
 	fs.Int64Var(&cfg.FileTargetSize, "file-target-size", (100 * 1024 * 1024), "Target size of files")
 	fs.Int64Var(&cfg.BulkInsertLimit, "bulk-insert-limit", (16 * 1024 * 1024), "Bulk insert limit")
@@ -49,7 +49,6 @@ type Config struct {
 	MySQLPoolSize     int    `toml:"mysql-pool-size" json:"mysql-pool-size"`
 	TidbSnapshot      string `toml:"tidb-snapshot" json:"tidb-snapshot"`
 	LogLevel          string `toml:"log-level" json:"log-level"`
-	LogFile           string `toml:"log-file" json:"log-file"`
 	TmpDir            string `toml:"tmpdir" json:"tmpdir"` // does nothing yet
 	FileTargetSize    int64  `toml:"file-target-size" json:"file-target-size"`
 	BulkInsertLimit   int64  `toml:"bulk-insert-limit" json:"bulk-insert-limit"`
@@ -61,7 +60,7 @@ type Config struct {
 func (c *Config) String() string {
 	bytes, err := json.Marshal(c)
 	if err != nil {
-		log.Errorf("[loader] marshal config to json error %v", err)
+		zap.S().Errorf("[loader] marshal config to json error %v", err)
 	}
 	return string(bytes)
 }

--- a/dumptable.go
+++ b/dumptable.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	_ "github.com/go-sql-driver/mysql"
-	"github.com/ngaut/log"
 	"math"
 	"os"
 	"sync/atomic"
+
+	_ "github.com/go-sql-driver/mysql"
+	"go.uber.org/zap"
 )
 
 type dumpTable struct {
@@ -122,7 +123,7 @@ func (dt *dumpTable) dumpCreateTable() {
 	tx.Commit()
 
 	if err != nil {
-		log.Fatal("Could not SHOW CREATE TABLE for %s.%s: %s", dt.schema, dt.table, err)
+		zap.S().Fatalf("Could not SHOW CREATE TABLE for %s.%s: %s", dt.schema, dt.table, err)
 	}
 
 	dt.createTable = fmt.Sprintf("%s;\n", dt.createTable)
@@ -133,13 +134,13 @@ func (dt *dumpTable) dumpCreateTable() {
 		defer f.Close()
 
 		if err != nil {
-			log.Fatal("Could not create temporary file: %s", dt.schemaFile)
+			zap.S().Fatalf("Could not create temporary file: %s", dt.schemaFile)
 		}
 
 		n, err := f.WriteString(dt.createTable)
 
 		if err != nil {
-			log.Fatal("Could not write %d bytes to temporary file: %s", n, dt.schemaFile)
+			zap.S().Fatalf("Could not write %d bytes to temporary file: %s", n, dt.schemaFile)
 		}
 
 		atomic.AddInt64(&dt.d.bytesDumped, int64(n))


### PR DESCRIPTION
This supports structured logging and is faster.
Its singleton logger is more incovenient,
but we should switch to injecting the log dependency anyways.